### PR TITLE
Fix dropped rubocop Rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ AllCops:
     - 'vendor/**/*'
   TargetRubyVersion: 2.3
 
+Rails:
+  Enabled: true
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
うっかり #34 で削除してしまったので復活させる。