### PR TITLE
Fix the following CircleCI warning

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,15 +8,14 @@ jobs:
       - image: postgres:9.5-alpine
     working_directory: /home/circleci/github-organization-watcher
     steps:
-      - checkout
       - setup_remote_docker:
           # https://circleci.com/docs/2.0/docker-layer-caching/
           reusable: true
       - run:
           name: Install System Dependencies
-          # tar and gzip are required by restore_cache section
-          # https://discuss.circleci.com/t/does-clear-cache-work-for-2-0/10965/13
-          command: apk add --update --no-cache build-base postgresql-dev postgresql-libs nodejs tzdata tar gzip
+          # See also https://circleci.com/docs/2.0/custom-images/#required-tools
+          command: apk add --update --no-cache git openssh-client tar gzip build-base postgresql-dev postgresql-libs nodejs tzdata
+      - checkout
       - restore_cache:
           name: Restore bundler cache
           keys:


### PR DESCRIPTION
Improve #48

https://circleci.com/gh/masutaka/github-organization-watcher/182

```
Checkout code

Warning: Either git  or ssh (required by git to  clone through SSH) is
not  installed in  the image.  Falling back  to CircleCI's  native git
client but  this is still  an experiment feature. We  highly recommend
using an image that has official git and ssh installed.
```