### PR TITLE
Use redis as session store 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       - image: ruby:2.4.1-alpine
         environment:
           RDB_URL_BASE: postgres://postgres:@localhost
-          REDIS_URL_BASE: redis://localhost:6379
+          REDIS_URL: redis://localhost:6379
       - image: postgres:9.5-alpine
       - image: redis:3.2-alpine
     working_directory: /work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,9 @@ jobs:
       - image: ruby:2.4.1-alpine
         environment:
           RDB_URL_BASE: postgres://postgres:@localhost
+          REDIS_URL_BASE: redis://localhost:6379
       - image: postgres:9.5-alpine
+      - image: redis:3.2-alpine
     working_directory: /work
     steps:
       - run:

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'hashie'
 gem 'octokit'
 gem 'omniauth-github'
 gem 'parallel'
+gem 'redis-rails'
 gem 'slim-rails'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,23 @@ GEM
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
+    redis (3.3.3)
+    redis-actionpack (5.0.1)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 1.4.0)
+    redis-activesupport (5.0.3)
+      activesupport (>= 3, < 6)
+      redis-store (~> 1.3.0)
+    redis-rack (2.0.2)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 1.4)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.3.0)
+      redis (>= 2.2)
     reek (4.6.1)
       codeclimate-engine-rb (~> 0.4.0)
       parser (>= 2.3.1.2, < 2.5)
@@ -342,6 +359,7 @@ DEPENDENCIES
   rack_session_access
   rails (~> 5.0.0)
   rails_best_practices
+  redis-rails
   rspec-rails
   rspec_junit_formatter
   rubocop
@@ -358,6 +376,5 @@ DEPENDENCIES
   web-console
   webmock
 
-
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/app.json
+++ b/app.json
@@ -17,6 +17,12 @@
 	    "options": {
 		"version": "9.5"
 	    }
+	},
+	{
+	    "plan": "heroku-redis",
+	    "options": {
+		"version": "3.2"
+	    }
 	}
     ]
 }

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_github-organization-watcher_session'
+Rails.application.config.session_store :redis_store,
+                                       servers: "#{ENV['REDIS_URL_BASE']}/0/session"

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :redis_store,
-                                       servers: "#{ENV['REDIS_URL_BASE']}/0/session"
+                                       servers: "#{ENV['REDIS_URL']}/0/session"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 3000:3000
     environment:
       RDB_URL_BASE: postgres://postgres:@rdb
-      REDIS_URL_BASE: redis://redis:6379
+      REDIS_URL: redis://redis:6379
       GITHUB_KEY: $GITHUB_KEY
       GITHUB_SECRET: $GITHUB_SECRET
     command: rails s -b 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,24 @@ services:
       - 3000:3000
     environment:
       RDB_URL_BASE: postgres://postgres:@rdb
+      REDIS_URL_BASE: redis://redis:6379
       GITHUB_KEY: $GITHUB_KEY
       GITHUB_SECRET: $GITHUB_SECRET
     command: rails s -b 0.0.0.0
     depends_on:
       - rdb
+      - redis
   rdb:
     image: postgres:9.5-alpine
     ports:
       - 15432:5432 # for convenience
+  redis:
+    image: redis:3.2-alpine
+    ports:
+      - 16379:6379 # for convenience
+    volumes:
+      - redis_data:/data
 
 volumes:
   share:
+  redis_data:


### PR DESCRIPTION
Heroku は毎日インスタンスが捨てられるので、デフォルトの `:cookie_store` だと手動で cookie を消す必要がある。開発環境も Docker なので、似たような現象になる。

セッションストアに Redis を使うことにする。